### PR TITLE
fix failing tests when using dataProviders

### DIFF
--- a/examples/simple/tests/ExampleTest.php
+++ b/examples/simple/tests/ExampleTest.php
@@ -24,13 +24,28 @@ class ExampleTest extends TestCase
         $this->assertSame($actual, $expected);
     }
 
-    protected function exampleDataProvider()
+    public function exampleDataProvider()
     {
         return [
             [true, true],
             [false, false],
             [1, 1],
             ['example', 'example'],
+        ];
+    }
+
+    /**
+     * @dataProvider exampleSecondDataProvider
+     */
+    public function testWithAnotherDataProvider($actual, $expected)
+    {
+        $this->assertSame($actual, $expected);
+    }
+
+    public function exampleSecondDataProvider()
+    {
+        return [
+            [true, true],
         ];
     }
 }

--- a/examples/simple/tests/ExampleTest.php
+++ b/examples/simple/tests/ExampleTest.php
@@ -6,7 +6,6 @@ use PHPUnit\Framework\TestCase;
 
 class ExampleTest extends TestCase
 {
-
     public function testItWorks()
     {
         $this->assertTrue(true);
@@ -15,5 +14,23 @@ class ExampleTest extends TestCase
     public function testItFails()
     {
         $this->assertTrue(false);
+    }
+
+    /**
+     * @dataProvider exampleDataProvider
+     */
+    public function testWithDataProvider($actual, $expected)
+    {
+        $this->assertSame($actual, $expected);
+    }
+
+    protected function exampleDataProvider()
+    {
+        return [
+            [true, true],
+            [false, false],
+            [1, 1],
+            ['example', 'example'],
+        ];
     }
 }

--- a/src/phpunit.js
+++ b/src/phpunit.js
@@ -20,7 +20,7 @@ const parse = (result) => {
   return {
     failures: parseInt(output.$.failures, 0),
     passes: parseInt(output.$.tests, 0) - parseInt(output.$.failures, 0),
-    tests: output.testcase.map(testcase => ({
+    tests: (output.testcase || output.testsuite[0].testcase).map(testcase => ({
       ancestorTitles: [],
       duration: parseFloat(testcase.$.time) * 1000,
       title: testcase.$.name,

--- a/src/phpunit.js
+++ b/src/phpunit.js
@@ -14,21 +14,30 @@ const run = (testPath, outputFile) => new Promise((resolve, reject) => {
 
 const cleanUp = file => fs.unlinkSync(file);
 
+const mapTestcases = function mapTestcases(testcases) {
+  return testcases.map(testcase => ({
+    ancestorTitles: [],
+    duration: parseFloat(testcase.$.time) * 1000,
+    title: testcase.$.name,
+    fullName: `${testcase.$.class}::${testcase.$.name}`,
+    failureMessages: testcase.failure ? testcase.failure.map(failure => failure._) : [],
+    status: testcase.failure ? 'failed' : 'passed',
+    numPassingAsserts: parseInt(testcase.$.assertions, 0),
+  }));
+};
+
 const parse = (result) => {
   const output = result.testsuites.testsuite[0];
 
   return {
     failures: parseInt(output.$.failures, 0),
     passes: parseInt(output.$.tests, 0) - parseInt(output.$.failures, 0),
-    tests: (output.testcase || output.testsuite[0].testcase).map(testcase => ({
-      ancestorTitles: [],
-      duration: parseFloat(testcase.$.time) * 1000,
-      title: testcase.$.name,
-      fullName: `${testcase.$.class}::${testcase.$.name}`,
-      failureMessages: testcase.failure ? testcase.failure.map(failure => failure._) : [],
-      status: testcase.failure ? 'failed' : 'passed',
-      numPassingAsserts: parseInt(testcase.$.assertions, 0),
-    })),
+    tests: [
+      ...(output.testcase ? mapTestcases(output.testcase) : []),
+      ...(output.testsuite ? output.testsuite.reduce(
+        (allTests, testSuite) => [...allTests, ...mapTestcases(testSuite.testcase)], []) : []
+      ),
+    ],
   };
 };
 


### PR DESCRIPTION
This should fix #1 

(I am trying to make the tests work on CI but no luck so far, @olyckne if you could help me out here would be awesome 😅)

It might be that there is still a problem if you have multiple dataProvider tests I think, I am not 100% sure.

I am a bit afraid of the `[0]` part where we only use the 1st item in the array.